### PR TITLE
Fix problem with boost += assignment

### DIFF
--- a/include/AGILe/Tools/AGILePaths.hh
+++ b/include/AGILe/Tools/AGILePaths.hh
@@ -21,6 +21,9 @@ namespace AGILe {
   /// Get LCG platform tag
   std::string getLCGPlatformTag();
 
+  /// Utility to append a vector of strings to another (Introduced since the += operator from
+  /// boost assign failed to work for boost > 1.68)
+  void vectorAppend(vector<string>& to, vector<string> const& from);
 
 }
 

--- a/src/Core/Loader.cc
+++ b/src/Core/Loader.cc
@@ -88,13 +88,13 @@ namespace AGILe {
 
         // And then the user's (non-system) library path (inc. for dyld on OS X)
         const char* envld = getenv("LD_LIBRARY_PATH");
-        if (envld) dirs += split(envld);
+        if (envld) vectorAppend(dirs, split(envld));
         const char* envdyld = getenv("DYLD_LIBRARY_PATH");
-        if (envdyld) dirs += split(envdyld);
+        if (envdyld) vectorAppend(dirs, split(envdyld));
 
       } else {
         // If we're loading a real generator library...
-        dirs += getGenPaths();
+        vectorAppend(dirs, getGenPaths());
       }
 
       return dirs;

--- a/src/Tools/AGILePaths.cc
+++ b/src/Tools/AGILePaths.cc
@@ -1,8 +1,14 @@
 #include "AGILe/AGILe.hh"
 #include "AGILe/Utils.hh"
 #include "binreloc.h"
+#include <algorithm>
 
 namespace AGILe {
+
+  
+  void vectorAppend(vector<string>& to, vector<string> const& from) {
+    std::copy(from.begin(), from.end(), std::back_inserter(to));
+  }
 
 
   string getLibPath() {
@@ -36,7 +42,7 @@ namespace AGILe {
     env = getenv("AGILE_GEN_PATH");
     if (env) {
       // Use the AGILe generator path variable if set...
-      dirs += split(env);
+      vectorAppend(dirs, split(env));
     } else {
       // Fall back to the Genser area on CERN AFS
       /// @todo deprecate Use of $AGILE_USE_AFS variable


### PR DESCRIPTION
Since boost 1.69.00, the expression
```
a += b;
```
where a and b are std::vector<std::string> does no longer
compile.

The documentation of operator+= in boost assign says that
the right hand expression must be convertable to value_type of the
underlying container. Not sure why this compiled previously with
b being a std::vector.

The patch brought forward here is to replace all
occurences of relevant += by a function call to a `vectorAppend`
function. This should work regardless of the boost version.